### PR TITLE
Corrigir redirecionamento após login

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -39,10 +39,13 @@ api.interceptors.response.use(
       switch (status) {
         case 401:
           // Token expirado ou inválido
-          localStorage.removeItem('token');
-          localStorage.removeItem('user');
-          toast.error('Sessão expirada. Faça login novamente.');
-          window.location.href = '/login';
+          // Só redirecionar se não estivermos já na página de login
+          if (!window.location.pathname.includes('/login')) {
+            localStorage.removeItem('token');
+            localStorage.removeItem('user');
+            toast.error('Sessão expirada. Faça login novamente.');
+            window.location.href = '/login';
+          }
           break;
           
         case 403:

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -53,7 +53,7 @@ const authService = {
   logout() {
     localStorage.removeItem('token');
     localStorage.removeItem('user');
-    window.location.href = '/login';
+    // Não forçar redirecionamento aqui, deixar o componente gerenciar
   },
 
   // Obter dados do usuário atual


### PR DESCRIPTION
Prevents redirection to login page after successful login.

The issue stemmed from a race condition where `checkAuth` was too aggressive in clearing authentication state if an online validation failed, coupled with an API interceptor that forced redirection on any 401 error, even when valid local authentication data existed or the user was already on the login page.